### PR TITLE
Add missing <Frequency> element

### DIFF
--- a/mcu/STM32F303K(6-8)Ux.xml
+++ b/mcu/STM32F303K(6-8)Ux.xml
@@ -2,6 +2,7 @@
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32F3" DBVersion="V3.0" Family="STM32F3" HasPowerPad="false" IOType="" Line="STM32F3x3" Package="UFQFPN32" RefName="STM32F303K(6-8)Ux" xmlns="http://dummy.com">
 	<Core>Arm Cortex-M4</Core>
+	<Frequency>72</Frequency>
 	<CCMRam>4</CCMRam>
 	<Ram>12</Ram>
 	<Ram>12</Ram>

--- a/mcu/STM32F401C(B-C)Yx.xml
+++ b/mcu/STM32F401C(B-C)Yx.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32F4_F401" DBVersion="V3.0" Family="STM32F4" HasPowerPad="false" IOType="" Line="STM32F401" Package="WLCSP49" RefName="STM32F401C(B-C)Yx" xmlns="http://dummy.com">
+	<Frequency>84</Frequency>
 	<Core>Arm Cortex-M4</Core>
 	<Ram>64</Ram>
 	<IONb>36</IONb>

--- a/mcu/STM32G473V(B-C-E)Ix.xml
+++ b/mcu/STM32G473V(B-C-E)Ix.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32G4" DBVersion="V3.0" Family="STM32G4" HasPowerPad="false" IOType="" Line="STM32G4x3" Package="UFBGA100" RefName="STM32G473V(B-C-E)Ix" xmlns="http://dummy.com">
+	<Frequency>170</Frequency>
 	<Core>ARM Cortex-M4</Core>
 	<Ram>128</Ram>
 	<IONb>86</IONb>

--- a/mcu/STM32G483VEIx.xml
+++ b/mcu/STM32G483VEIx.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32G4" DBVersion="V3.0" Family="STM32G4" HasPowerPad="false" IOType="" Line="STM32G4x3" Package="UFBGA100" RefName="STM32G483VEIx" xmlns="http://dummy.com">
+	<Frequency>170</Frequency>
 	<Core>ARM Cortex-M4</Core>
 	<Ram>128</Ram>
 	<IONb>86</IONb>

--- a/mcu/STM32G484VEIx.xml
+++ b/mcu/STM32G484VEIx.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32G4" DBVersion="V3.0" Family="STM32G4" HasPowerPad="false" IOType="" Line="STM32G4x4" Package="UFBGA100" RefName="STM32G484VEIx" xmlns="http://dummy.com">
+	<Frequency>170</Frequency>
 	<Core>ARM Cortex-M4</Core>
 	<Ram>128</Ram>
 	<IONb>86</IONb>

--- a/mcu/STM32L021F4Px.xml
+++ b/mcu/STM32L021F4Px.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32L0" DBVersion="V3.0" Family="STM32L0" HasPowerPad="false" IOType="" Line="STM32L0x1" Package="TSSOP20" RefName="STM32L021F4Px" xmlns="http://dummy.com">
+	<Frequency>32</Frequency>
 	<Core>Arm Cortex-M0+</Core>
 	<E2prom>512</E2prom>
 	<Ram>2</Ram>

--- a/mcu/STM32L021K4Ux.xml
+++ b/mcu/STM32L021K4Ux.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32L0" DBVersion="V3.0" Family="STM32L0" HasPowerPad="true" IOType="" Line="STM32L0x1" Package="UFQFPN32" RefName="STM32L021K4Ux" xmlns="http://dummy.com">
+	<Frequency>32</Frequency>
 	<Core>Arm Cortex-M0+</Core>
 	<E2prom>512</E2prom>
 	<Ram>2</Ram>

--- a/mcu/STM32L071V(B-Z)Ix.xml
+++ b/mcu/STM32L071V(B-Z)Ix.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32L0" DBVersion="V3.0" Family="STM32L0" HasPowerPad="false" IOType="" Line="STM32L0x1" Package="UFBGA100" RefName="STM32L071V(B-Z)Ix" xmlns="http://dummy.com">
+	<Frequency>32</Frequency>
 	<Core>Arm Cortex-M0+</Core>
 	<E2prom>6144</E2prom>
 	<Ram>20</Ram>

--- a/mcu/STM32L071V8Ix.xml
+++ b/mcu/STM32L071V8Ix.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32L0" DBVersion="V3.0" Family="STM32L0" HasPowerPad="false" IOType="" Line="STM32L0x1" Package="UFBGA100" RefName="STM32L071V8Ix" xmlns="http://dummy.com">
+	<Frequency>32</Frequency>
 	<Core>Arm Cortex-M0+</Core>
 	<E2prom>3072</E2prom>
 	<Ram>20</Ram>

--- a/mcu/STM32L073V8Ix.xml
+++ b/mcu/STM32L073V8Ix.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2021 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32L0" DBVersion="V3.0" Family="STM32L0" HasPowerPad="false" IOType="" Line="STM32L0x3" Package="UFBGA100" RefName="STM32L073V8Ix" xmlns="http://dummy.com">
+	<Frequency>32</Frequency>
 	<Core>Arm Cortex-M0+</Core>
 	<E2prom>3072</E2prom>
 	<Ram>20</Ram>

--- a/mcu/STM32L083V8Ix.xml
+++ b/mcu/STM32L083V8Ix.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2021 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32L0" DBVersion="V3.0" Family="STM32L0" HasPowerPad="false" IOType="" Line="STM32L0x3" Package="UFBGA100" RefName="STM32L083V8Ix" xmlns="http://dummy.com">
+	<Frequency>32</Frequency>
 	<Core>Arm Cortex-M0+</Core>
 	<E2prom>3072</E2prom>
 	<Ram>20</Ram>

--- a/mcu/STM32U575OGYxQ.xml
+++ b/mcu/STM32U575OGYxQ.xml
@@ -6,6 +6,7 @@
 	<ContextProject Attributes="DUAL,TZ" Comment="with TrustZone activated ?" Contexts="CortexM33S,CortexM33NS" Name="TrustZoneEnabled"/>
 	<Context Comment="Enable the Cortex-M33 secure context for the peripheral(s) that you want to use from the secure world, whether a basic secure monitor or a trusted execution environment" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33 secure" Name="CortexM33S" Secure="true" SemaphoreSuffix="_SECURE" ShortName="M33S"/>
 	<Context Comment="Enable the Cortex-M33 non-secure context for the peripheral(s) that you plan to use from the non secure world" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33 non secure" Name="CortexM33NS" Secure="false" SemaphoreSuffix="_NON_SECURE" ShortName="M33NS"/>
+	<Frequency>160</Frequency>
 	<Context Comment="Enable the Cortex-M33 context for the peripheral(s) that you plan to use" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33" Name="CortexM33" Secure="false" SemaphoreSuffix="_NON_SECURE" ShortName="M33"/>
 	<TrustZone>Available</TrustZone>
 	<Ram>256</Ram>

--- a/mcu/STM32U585QEIxQ.xml
+++ b/mcu/STM32U585QEIxQ.xml
@@ -6,6 +6,7 @@
 	<ContextProject Attributes="DUAL,TZ" Comment="with TrustZone activated ?" Contexts="CortexM33S,CortexM33NS" Name="TrustZoneEnabled"/>
 	<Context Comment="Enable the Cortex-M33 secure context for the peripheral(s) that you want to use from the secure world, whether a basic secure monitor or a trusted execution environment" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33 secure" Name="CortexM33S" Secure="true" SemaphoreSuffix="_SECURE" ShortName="M33S"/>
 	<Context Comment="Enable the Cortex-M33 non-secure context for the peripheral(s) that you plan to use from the non secure world" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33 non secure" Name="CortexM33NS" Secure="false" SemaphoreSuffix="_NON_SECURE" ShortName="M33NS"/>
+	<Frequency>160</Frequency>
 	<Context Comment="Enable the Cortex-M33 context for the peripheral(s) that you plan to use" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33" Name="CortexM33" Secure="false" SemaphoreSuffix="_NON_SECURE" ShortName="M33"/>
 	<TrustZone>Available</TrustZone>
 	<Ram>256</Ram>

--- a/mcu/STM32U585ZETxQ.xml
+++ b/mcu/STM32U585ZETxQ.xml
@@ -6,6 +6,7 @@
 	<ContextProject Attributes="DUAL,TZ" Comment="with TrustZone activated ?" Contexts="CortexM33S,CortexM33NS" Name="TrustZoneEnabled"/>
 	<Context Comment="Enable the Cortex-M33 secure context for the peripheral(s) that you want to use from the secure world, whether a basic secure monitor or a trusted execution environment" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33 secure" Name="CortexM33S" Secure="true" SemaphoreSuffix="_SECURE" ShortName="M33S"/>
 	<Context Comment="Enable the Cortex-M33 non-secure context for the peripheral(s) that you plan to use from the non secure world" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33 non secure" Name="CortexM33NS" Secure="false" SemaphoreSuffix="_NON_SECURE" ShortName="M33NS"/>
+	<Frequency>160</Frequency>
 	<Context Comment="Enable the Cortex-M33 context for the peripheral(s) that you plan to use" Core="ARM Cortex-M33" GenType="CUBE" GroupName="Runtime contexts" GroupShortName="RT" LongName="Cortex-M33" Name="CortexM33" Secure="false" SemaphoreSuffix="_NON_SECURE" ShortName="M33"/>
 	<TrustZone>Available</TrustZone>
 	<Ram>256</Ram>

--- a/mcu/STM32WB30CEUxA.xml
+++ b/mcu/STM32WB30CEUxA.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32W" DBVersion="V3.0" Family="STM32WB" HasPowerPad="false" IOType="" Line="STM32WBx0 Value Line" Package="UFQFPN48" RefName="STM32WB30CEUxA" xmlns="http://dummy.com">
+	<Frequency>64</Frequency>
 	<Core>ARM Cortex-M4</Core>
 	<Ram>96</Ram>
 	<IONb>30</IONb>

--- a/mcu/STM32WB35C(C-E)UxA.xml
+++ b/mcu/STM32WB35C(C-E)UxA.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Copyright (c) 2020 STMicroelectronics. All rights reserved. -->
 <Mcu ClockTree="STM32W" DBVersion="V3.0" Family="STM32WB" HasPowerPad="false" IOType="" Line="STM32WBx5" Package="UFQFPN48" RefName="STM32WB35C(C-E)UxA" xmlns="http://dummy.com">
+	<Frequency>64</Frequency>
 	<Core>ARM Cortex-M4</Core>
 	<Ram>96</Ram>
 	<IONb>30</IONb>


### PR DESCRIPTION
This adds all missing `<Frequency>` elements for all STM32 devices except the MP series (which was missing all tags, so I don't know what frequency they run at).

You can check for missing elements via ack:

```
 $ cd mcu
 $ ack "<Frequency>" -L -n | sort
STM32F303K(6-8)Ux.xml
STM32F401C(B-C)Yx.xml
STM32G473V(B-C-E)Ix.xml
STM32G483VEIx.xml
STM32G484VEIx.xml
STM32L021F4Px.xml
STM32L021K4Ux.xml
STM32L071V(B-Z)Ix.xml
STM32L071V8Ix.xml
STM32L073V8Ix.xml
STM32L083V8Ix.xml
# ignoring STM32MP*
STM32U575OGYxQ.xml
STM32U585QEIxQ.xml
STM32U585ZETxQ.xml
STM32WB30CEUxA.xml
STM32WB35C(C-E)UxA.xml
```